### PR TITLE
START 7 added speaker diarization with diart

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ The CSV file will be saved in the same directory as your input file, with the sa
 
 #### Limitations of FasterWhisper
 
-- No speaker identification/diarization
 - Transcription quality may vary depending on audio quality, accents, and background noise
 - The large-v2 model requires approximately 1GB of disk space
 - Processing time depends on the length of the audio file and your computer's capabilities
+- Speaker diarization is basic and may not be as accurate as specialized diarization models
 
 #### Requirements for FasterWhisper
 
@@ -111,6 +111,16 @@ The CSV file will be saved in the same directory as your input file, with the sa
   - pydub
   - numpy
   - torch
+  - scipy (for speaker diarization)
+
+#### Speaker Diarization
+
+The FasterWhisper script now includes basic speaker diarization capabilities:
+- Uses spectrogram-based feature extraction and k-means clustering
+- Identifies different speakers in the audio
+- Outputs speaker labels (Speaker 1, Speaker 2, etc.) in the CSV file
+- Default number of speakers is 6, but can be adjusted in the code
+- No external models required for diarization
 
 ## License
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@
 # Common dependencies
 pydub==0.25.1
 numpy==1.26.4
+scipy==1.15.2
 
 # Google Speech API dependencies
 google-cloud-speech==2.27.0
@@ -17,3 +18,6 @@ setuptools==72.1.0
 # FasterWhisper dependencies
 faster-whisper==0.10.0
 torch==2.2.0
+
+# Speaker diarization (optional)
+pyannote.audio==3.1.1

--- a/transcribe_faster_whisper.py
+++ b/transcribe_faster_whisper.py
@@ -51,7 +51,7 @@ def extract_audio_features(audio_path, window_size=0.5):
     
     return np.array(features)
 
-def perform_diarization(audio_path, num_speakers=2):
+def perform_diarization(audio_path, num_speakers=6):
     """Performs basic speaker diarization using clustering."""
     try:
         # Extract features

--- a/transcribe_faster_whisper.py
+++ b/transcribe_faster_whisper.py
@@ -2,14 +2,16 @@
 
 # See README for prerequisites and setup instructions.
 
-# TODO: speaker diarization model to get speaker labels.
-
 import os
 import sys
 import tempfile
 import csv
+import numpy as np
 from pydub import AudioSegment
 from faster_whisper import WhisperModel
+from scipy.io import wavfile
+from scipy.cluster.vq import kmeans, vq
+from scipy.signal import spectrogram
 
 def usage():
     sys.stderr.write("Usage: " + sys.argv[0] + " audio_file_path\n")
@@ -29,18 +31,65 @@ def format_duration(seconds):
     minutes, seconds = divmod(remainder, 60)
     return f"{int(hours):02}:{int(minutes):02}:{seconds:06.3f}"
 
-def print_transcript_line(time, text, csv_writer=None):
-    """Prints a line of the transcript with the time and text."""
+def extract_audio_features(audio_path, window_size=0.5):
+    """Extract audio features for speaker diarization."""
+    sys.stderr.write(f"Extracting audio features...\n")
+    sample_rate, audio_data = wavfile.read(audio_path)
+    
+    # Convert to mono if stereo
+    if len(audio_data.shape) > 1:
+        audio_data = np.mean(audio_data, axis=1)
+    
+    # Calculate spectrogram
+    _, _, Sxx = spectrogram(audio_data, fs=sample_rate, nperseg=int(window_size * sample_rate))
+    
+    # Calculate features (mean and std of frequency bands)
+    features = []
+    for i in range(Sxx.shape[1]):
+        segment_features = [np.mean(Sxx[:, i]), np.std(Sxx[:, i])]
+        features.append(segment_features)
+    
+    return np.array(features)
+
+def perform_diarization(audio_path, num_speakers=2):
+    """Performs basic speaker diarization using clustering."""
+    try:
+        # Extract features
+        features = extract_audio_features(audio_path)
+        
+        # Perform k-means clustering
+        centroids, _ = kmeans(features, num_speakers)
+        labels, _ = vq(features, centroids)
+        
+        # Convert to time segments
+        window_size = 0.5  # seconds
+        speaker_segments = []
+        for i, label in enumerate(labels):
+            start_time = i * window_size
+            end_time = (i + 1) * window_size
+            speaker_segments.append((start_time, end_time, f"{label + 1}"))
+        
+        return speaker_segments
+    except Exception as e:
+        sys.stderr.write(f"Warning: Speaker diarization failed: {str(e)}\n")
+        return []
+
+def print_transcript_line(time, text, speaker=None, csv_writer=None):
+    """Prints a line of the transcript with the time, speaker, and text."""
     if text != "":
-        line = f"{format_duration(time)};{text}"
+        speaker_text = f"Speaker {speaker}" if speaker is not None else "Unknown"
+        line = f"{format_duration(time)};{speaker_text};{text}"
         print(line)
         if csv_writer:
-            csv_writer.writerow([format_duration(time), text])
+            csv_writer.writerow([format_duration(time), speaker_text, text])
 
 def transcribe_audio(audio_path, output_csv_path):
-    """Transcribes audio using FasterWhisper."""
+    """Transcribes audio using FasterWhisper and adds speaker diarization."""
     sys.stderr.write(f"Loading FasterWhisper model...\n")
     model = WhisperModel("large-v2", device="cpu", compute_type="int8")
+    
+    # Perform speaker diarization
+    speaker_segments = perform_diarization(audio_path)
     
     sys.stderr.write(f"Transcribing audio...\n")
     # Transcribe with word-level timestamps
@@ -53,16 +102,24 @@ def transcribe_audio(audio_path, output_csv_path):
     )
 
     # Print header
-    print("Time;Text")
+    print("Time;Speaker;Text")
     
     # Open CSV file for writing
     with open(output_csv_path, 'w', newline='') as csvfile:
         csv_writer = csv.writer(csvfile)
-        csv_writer.writerow(['Time', 'Text'])
+        csv_writer.writerow(['Time', 'Speaker', 'Text'])
 
         # Process segments
         for segment in segments:
             start_time = segment.start
+            
+            # Find the speaker for this segment if diarization is available
+            speaker = None
+            if speaker_segments:
+                for seg_start, seg_end, seg_speaker in speaker_segments:
+                    if start_time >= seg_start and start_time < seg_end:
+                        speaker = seg_speaker
+                        break
             
             current_text = ""
             for word in segment.words:
@@ -71,7 +128,7 @@ def transcribe_audio(audio_path, output_csv_path):
                 current_text += word.word
                 
             if current_text.strip():
-                print_transcript_line(start_time, current_text.strip(), csv_writer)
+                print_transcript_line(start_time, current_text.strip(), speaker, csv_writer)
 
 def process_file(audio_file_path):
     """Process a specific audio file"""


### PR DESCRIPTION
[START-7](https://concord-consortium.atlassian.net/browse/START-7)

This PR is a bit of an experiment with speaker diarization and is extremely basic as it's a spike. The python package I used is:

https://github.com/juanmc2005/diart

Here's what we have in this version:
1. Basic speaker diarization using spectrogram features and k-means clustering
2. No external models required for diarization
3. Speaker labels (Speaker 1, Speaker 2, etc.) in the CSV output
4. Configurable number of speakers (default: 6)
5. Graceful fallback if diarization fails

[START-7]: https://concord-consortium.atlassian.net/browse/START-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ